### PR TITLE
fix_otf2: task id generation call to get thread id is changed so that…

### DIFF
--- a/src/apex/task_identifier.cpp
+++ b/src/apex/task_identifier.cpp
@@ -26,7 +26,10 @@ namespace apex {
 // only let one thread at a time resolve the name of this task
 std::mutex bfd_mutex;;
 
-    task_identifier::apex_name_map::apex_name_map() : tid(thread_instance::get_id()) {};
+    // the get_id_non_worker_task_guid call ensures that a new worker thread instance will not be 
+    // created. rather a non worker thread instance will be created or the id will be returned
+    task_identifier::apex_name_map::apex_name_map() : tid(thread_instance::get_id_non_worker_task_guid()) {};
+    //task_identifier::apex_name_map::apex_name_map() : tid(thread_instance::get_id()) {};
     task_identifier::apex_name_map::~apex_name_map(void) {
         if (tid == 0) {
             finalize();
@@ -38,7 +41,11 @@ std::mutex bfd_mutex;;
            the program exits and the pointers aren't needed any more. */
     }
 
-    task_identifier::apex_addr_map::apex_addr_map() : tid(thread_instance::get_id()) {};
+    // the get_id_non_worker_task_guid call ensures that a new worker thread instance will not be 
+    // created. rather a non worker thread instance will be created or the id will be returned
+ 
+    task_identifier::apex_addr_map::apex_addr_map() : tid(thread_instance::get_id_non_worker_task_guid()) {};
+    //task_identifier::apex_addr_map::apex_addr_map() : tid(thread_instance::get_id()) {};
     task_identifier::apex_addr_map::~apex_addr_map(void) {
         if (tid == 0) {
             finalize();

--- a/src/apex/thread_instance.hpp
+++ b/src/apex/thread_instance.hpp
@@ -80,8 +80,19 @@ private:
 public:
   ~thread_instance(void);
   static thread_instance& instance(bool is_worker=true);
+  // this following funciton is for new task creation which may come from a new thread that we dont
+  // want to term as a worker thread
+  static thread_instance& instance_non_worker_task_guid(void);
   static void delete_instance();
-  static long unsigned int get_id(void) { return instance()._id; }
+  static long unsigned int get_id(void) { 
+      return instance()._id; 
+  }
+
+  // this following funciton is called to avoid default is_worker=true 
+  static long unsigned int get_id_non_worker_task_guid(void) { 
+      return instance_non_worker_task_guid()._id; 
+  }
+ 
   static long unsigned int get_runtime_id(void) { return instance()._runtime_id; }
   static void set_runtime_id(long unsigned int id) { instance()._runtime_id = id; }
   static std::string get_name(void);


### PR DESCRIPTION
… a new worker thread instance is not created