### PR TITLE
Add hpx_assertion dependency

### DIFF
--- a/src/apex/CMakeLists.hpx
+++ b/src/apex/CMakeLists.hpx
@@ -371,7 +371,7 @@ add_hpx_library(apex
   NOEXPORT
   SOURCES ${apex_sources}
   HEADERS ${apex_headers}
-  DEPENDENCIES hpx_cache
+  DEPENDENCIES hpx_assertion hpx_cache
   FOLDER "Core/Dependencies")
 
 #if(APPLE)


### PR DESCRIPTION
The `assertion` module was just merged into HPX master (https://github.com/STEllAR-GROUP/hpx/pull/3845). This adds the dependency.