### PR TITLE
Change include_directories to target_include_directories

### DIFF
--- a/src/apex/CMakeLists.hpx
+++ b/src/apex/CMakeLists.hpx
@@ -35,8 +35,6 @@ set(APEX_BINARY_DIR ${APEX_BINARY_DIR} PARENT_SCOPE)
 hpx_info("apex" "APEX source dir is ${APEX_SOURCE_DIR}")
 hpx_info("apex" "APEX binary dir is ${APEX_BINARY_DIR}")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${APEX_BINARY_DIR} ${CMAKE_SOURCE_DIR}/apex/src/contrib)
-
 # This macro will make sure that the hpx/config.h file is included
 add_definitions(-DAPEX_HAVE_HPX_CONFIG)
 # This macro will be added to the hpx/config.h file.
@@ -381,6 +379,11 @@ add_hpx_library(apex
   HEADERS ${apex_headers}
   DEPENDENCIES hpx_assertion hpx_cache hpx_hardware
   FOLDER "Core/Dependencies")
+target_include_directories(apex PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<BUILD_INTERFACE:${APEX_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/apex/src/contrib>)
 
 #if(APPLE)
   #hpx_add_link_flag("-weak_library libhpx_taudummy.dylib -flat_namespace")


### PR DESCRIPTION
The goal is to remove the include_directories from HPX as it includes
the directories for ALL targets. We want to make those includes target
specific.