### PR TITLE
Fix more HPX modules dependencies and deprecated headers

### DIFF
--- a/src/apex/CMakeLists.hpx
+++ b/src/apex/CMakeLists.hpx
@@ -394,11 +394,24 @@ add_hpx_library(apex
   NOEXPORT
   SOURCES ${apex_sources}
   HEADERS ${apex_headers}
-  DEPENDENCIES hpx_algorithms hpx_allocator_support hpx_assertion hpx_cache
-  hpx_collectives hpx_concepts hpx_config hpx_datastructures hpx_format
-  hpx_hardware hpx_hashing hpx_iterator_support hpx_logging hpx_parallel_executors
-  hpx_preprocessor hpx_segmented_algorithms hpx_statistics hpx_testing
-  hpx_thread_support hpx_timing hpx_type_support hpx_util FOLDER "Core/Dependencies")
+  DEPENDENCIES
+    hpx_algorithms
+    hpx_allocator_support
+    hpx_assertion
+    hpx_cache
+    hpx_datastructures
+    hpx_errors
+    hpx_format
+    hpx_hardware
+    hpx_hashing
+    hpx_iterator_support
+    hpx_logging
+    hpx_parallel_executors
+    hpx_segmented_algorithms
+    hpx_thread_support
+    hpx_topology
+    hpx_util
+  FOLDER "Core/Dependencies")
 
 target_include_directories(apex PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Fix more hpx modules dependencies and remove the unsused ones.

Important : This changes are up-to-date with hpx's `origin/master` branch after the 4019 merge of module topology. 