### PR TITLE
WIP : Transform CMakeLists.hpx to use target based directives

### DIFF
--- a/cmake/Modules/APEX_SetupActiveHarmony.cmake
+++ b/cmake/Modules/APEX_SetupActiveHarmony.cmake
@@ -1,0 +1,32 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(APEX_WITH_ACTIVEHARMONY)
+
+  find_package(ActiveHarmony)
+  if(NOT ACTIVEHARMONY_FOUND)
+      hpx_error("apex" "Requested APEX_WITH_ACTIVEHARMONY but could not find \
+      Active Harmony. Please specify ACTIVEHARMONY_ROOT.")
+  endif()
+
+  # Add an imported target
+  add_library(apex::activeharmony INTERFACE IMPORTED)
+  hpx_info("apex" "Building APEX with Active Harmony support.")
+  set_property(TARGET apex::activeharmony PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${ACTIVEHARMONY_INCLUDE_DIR})
+  set_property(TARGET apex::activeharmony PROPERTY
+    INTERFACE_LINK_LIBRARIES ${ACTIVEHARMONY_LIBRARIES})
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${ACTIVEHARMONY_LIBRARY_DIR})
+
+  # Add the right definitions to the apex_flags target
+  target_compile_definitions(apex_flags INTERFACE APEX_HAVE_ACTIVEHARMONY)
+
+  list(APPEND _apex_imported_targets apex::activeharmony)
+
+else()
+
+  add_custom_target(project_activeharmony)
+
+endif()

--- a/cmake/Modules/APEX_SetupBFD.cmake
+++ b/cmake/Modules/APEX_SetupBFD.cmake
@@ -1,0 +1,20 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(BFD)
+
+if (BFD_FOUND)
+
+  add_library(apex::bfd INTERFACE IMPORTED)
+  set_property(TARGET apex::bfd PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${BFD_INCLUDE_DIRS})
+  set_property(TARGET apex::bfd PROPERTY
+    INTERFACE_LINK_LIBRARIES ${BFD_LIBRARIES})
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${BFD_LIBRARY_DIR})
+  message(INFO " Using binutils: ${BFD_LIBRARY_DIR} ${BFD_LIBRARIES}")
+
+  list(APPEND _apex_imported_targets apex::bfd)
+
+endif()

--- a/cmake/Modules/APEX_SetupDemangle.cmake
+++ b/cmake/Modules/APEX_SetupDemangle.cmake
@@ -1,0 +1,28 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(Demangle)
+
+if (DEMANGLE_FOUND)
+
+  # Add an imported target
+  add_library(apex::demangle INTERFACE IMPORTED)
+  set_property(TARGET apex::demangle PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${DEMANGLE_INCLUDE_DIRS})
+  set_property(TARGET apex::demangle PROPERTY
+    INTERFACE_LINK_LIBRARIES ${DEMANGLE_LIBRARIES})
+
+	set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${DEMANGLE_LIBRARY_DIR})
+  message(INFO " Using demangle: ${DEMANGLE_LIBRARY_DIR} ${DEMANGLE_LIBRARIES}")
+
+  list(APPEND _apex_imported_targets apex::demangle)
+
+else()
+
+	unset(DEMANGLE_LIBRARY)
+	unset(DEMANGLE_LIBRARIES)
+	unset(DEMANGLE_DIR)
+
+endif()

--- a/cmake/Modules/APEX_SetupLMSensors.cmake
+++ b/cmake/Modules/APEX_SetupLMSensors.cmake
@@ -1,0 +1,33 @@
+#  Copyright (c) 2014 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+################################################################################
+# LM Sensors configuration
+################################################################################
+
+# Setup an imported target for lmsensors
+if(APEX_WITH_LM_SENSORS)
+
+  find_package(LMSensors)
+
+  if (NOT LM_SENSORS_FOUND)
+    hpx_error("apex" "Requested APEX_WITH_LM_SENSORS but could not find LM \
+    Sensors. Please specify LM_SENSORS_ROOT.")
+  endif()
+
+  # Add an imported target
+  add_library(apex::lm_sensors INTERFACE IMPORTED)
+  set_property(TARGET apex::lm_sensors PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${LM_SENSORS_INCLUDE_DIRS})
+  set_property(TARGET apex::lm_sensors PROPERTY
+    INTERFACE_LINK_LIBRARIES ${LM_SENSORS_LIBRARIES})
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${LM_SENSORS_LIBRARY_DIR})
+
+  target_compile_definitions(apex_flags INTERFACE APEX_HAVE_LM_SENSORS)
+
+  list(APPEND _apex_imported_targets apex::lm_sensors)
+
+endif()
+

--- a/cmake/Modules/APEX_SetupMSR.cmake
+++ b/cmake/Modules/APEX_SetupMSR.cmake
@@ -1,0 +1,27 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(APEX_WITH_MSR)
+
+  find_package(MSR)
+  if(NOT MSR_FOUND)
+      hpx_error("apex" "Requested APEX_WITH_MSR but could not find MSR. \
+        Please specify MSR_ROOT.")
+  endif()
+  hpx_info("apex" "Building APEX with libmsr support.")
+
+  # Add an imported target
+  add_library(apex::msr INTERFACE IMPORTED)
+  set_property(TARGET apex::msr PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${MSR_INCLUDE_DIR})
+  set_property(TARGET apex::msr PROPERTY
+    INTERFACE_LINK_LIBRARIES ${MSR_LIBRARIES})
+
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${MSR_LIBRARY_DIR})
+  target_compile_definitions(apex_flags INTERFACE APEX_HAVE_MSR)
+
+  list(APPEND _apex_imported_targets apex::msr)
+
+endif()

--- a/cmake/Modules/APEX_SetupOTF2.cmake
+++ b/cmake/Modules/APEX_SetupOTF2.cmake
@@ -1,0 +1,28 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(APEX_WITH_OTF2)
+
+  find_package(OTF2 REQUIRED)
+  if (NOT OTF2_FOUND)
+      hpx_error("apex" "Requested APEX_WITH_OTF2 but could not find OTF2 library. Please specify OTF2_ROOT.")
+  endif()
+
+  # Add an imported target
+  add_library(apex::otf2 INTERFACE IMPORTED)
+  set_property(TARGET apex::otf2 PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${OTF2_INCLUDE_DIRS})
+  set_property(TARGET apex::otf2 PROPERTY
+    INTERFACE_LINK_LIBRARIES ${OTF2_LIBRARIES})
+
+  set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${OTF2_LIBRARY_DIR})
+  #target_compile_definitions(apex_flags INTERFACE APEX_USE_CLOCK_TIMESTAMP=1)
+
+  list(APPEND _apex_imported_targets apex::otf2)
+
+else()
+  add_custom_target(project_otf2)
+endif()
+

--- a/cmake/Modules/APEX_SetupPAPI.cmake
+++ b/cmake/Modules/APEX_SetupPAPI.cmake
@@ -1,0 +1,27 @@
+#  Copyright (c) 2014 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Setup an imported target for papi
+if(APEX_WITH_PAPI)
+
+  find_package(PAPI)
+  if(NOT PAPI_FOUND)
+      hpx_error("apex" "Requested APEX_WITH_PAPI but could not find PAPI. Please specify PAPI_ROOT.")
+  endif()
+  hpx_info("apex" "Building APEX with PAPI support.")
+
+  # Add an imported target
+  add_library(apex::papi INTERFACE IMPORTED)
+  set_property(TARGET apex::papi PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${PAPI_INCLUDE_DIR})
+  set_property(TARGET apex::papi PROPERTY
+    INTERFACE_LINK_LIBRARIES ${PAPI_LIBRARIES})
+
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${PAPI_LIBRARY_DIR})
+  target_compile_definitions(apex_flags INTERFACE APEX_HAVE_PAPI)
+
+  list(APPEND _apex_imported_targets apex::papi)
+
+endif()

--- a/cmake/Modules/APEX_SetupPlugins.cmake
+++ b/cmake/Modules/APEX_SetupPlugins.cmake
@@ -1,0 +1,35 @@
+#  Copyright (c) 2014 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(APEX_WITH_PLUGINS)
+  message(INFO " apex will be built with plugin support.")
+  set(LIBS ${LIBS} ${CMAKE_DL_LIBS})
+  target_compile_definitions(apex_flags INTERFACE APEX_USE_PLUGINS)
+
+  include(GitExternal)
+	git_external(rapidjson
+    https://github.com/miloyip/rapidjson.git
+    master
+    VERBOSE)
+
+	find_path(
+    RAPIDJSON_INCLUDE_DIR
+    NAMES rapidjson
+    PATHS ${APEX_SOURCE_DIR}/rapidjson/include)
+
+  add_library(apex::rapidjson INTERFACE IMPORTED)
+	if(RAPIDJSON_INCLUDE_DIR)
+    message(INFO " Found rapidjson at ${RAPIDJSON_INCLUDE_DIR}")
+    set_property(TARGET apex::rapidjson PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES ${RAPIDJSON_INCLUDE_DIR})
+
+  list(APPEND _apex_imported_targets apex::rapidjson)
+
+	else()
+    message(FATAL_ERROR " rapidjson not found. This should have been checked \
+      out automatically. " "Try manually check out \
+      https://github.com/miloyip/rapidjson.git to ${PROJECT_SOURCE_DIR}")
+	endif()
+endif()

--- a/cmake/Modules/APEX_SetupZlib.cmake
+++ b/cmake/Modules/APEX_SetupZlib.cmake
@@ -1,0 +1,19 @@
+#  Copyright (c) 2019 University of Oregon
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(ZLIB)
+
+if (ZLIB_FOUND)
+
+  # Add an imported target
+  add_library(apex::zlib INTERFACE IMPORTED)
+  set_property(TARGET apex::zlib PROPERTY
+    INTERFACE_LINK_LIBRARIES ${ZLIB_LIBRARIES})
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${ZLIB_LIBRARY_DIR})
+  message(INFO " Using zlib: ${ZLIB_LIBRARY_DIR} ${ZLIB_LIBRARIES}")
+
+  list(APPEND _apex_imported_targets apex::zlib)
+
+endif()

--- a/src/apex/CMakeLists.hpx
+++ b/src/apex/CMakeLists.hpx
@@ -10,7 +10,7 @@ cmake_policy(VERSION 2.8.12)
 if (${CMAKE_MAJOR_VERSION} GREATER 2)
   cmake_policy(SET CMP0042 NEW)
     if (${CMAKE_MINOR_VERSION} GREATER 11)
-        cmake_policy(SET CMP0074 NEW)
+      cmake_policy(SET CMP0074 NEW)
     endif()
 endif()
 
@@ -30,7 +30,6 @@ endif()
 # Module path both apex and hpx
 list(APPEND CMAKE_MODULE_PATH "${APEX_ROOT}/cmake/Modules")
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-include(HPX_Libraries)
 
 set(APEX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(APEX_SOURCE_DIR ${APEX_SOURCE_DIR} PARENT_SCOPE)
@@ -40,19 +39,22 @@ set(APEX_BINARY_DIR ${APEX_BINARY_DIR} PARENT_SCOPE)
 hpx_info("apex" "APEX source dir is ${APEX_SOURCE_DIR}")
 hpx_info("apex" "APEX binary dir is ${APEX_BINARY_DIR}")
 
+# Add a target to store the flags
+add_library(apex_flags INTERFACE)
+
 # This macro will make sure that the hpx/config.h file is included
-add_definitions(-DAPEX_HAVE_HPX_CONFIG)
+target_compile_definitions(apex_flags INTERFACE APEX_HAVE_HPX_CONFIG)
 # This macro will be added to the hpx/config.h file.
 hpx_add_config_define(APEX_HAVE_HPX)   # tell HPX that we use APEX
 
 if(APEX_DEBUG)
-    add_definitions(-DAPEX_DEBUG)
+  target_compile_definitions(apex_flags INTERFACE APEX_DEBUG)
 endif()
 
 # If TAU is used, don't allow throttling - it can potentially lead to
 # overlapping timer errors in TAU.
 #if((DEFINED APEX_THROTTLE) AND (APEX_THROTTLE))
-#    add_definitions(-DAPEX_THROTTLE)
+#  target_compile_definitions(apex_flags INTERFACE APEX_THROTTLE)
 #endif()
 
 # Check if architecture is x86 or not
@@ -65,28 +67,28 @@ endif()
 
 # If not x86, don't use RDTSC
 if(NOT APEX_ARCH_X86)
-  add_definitions(-DAPEX_USE_CLOCK_TIMESTAMP=1)
+  target_compile_definitions(apex_flags INTERFACE APEX_USE_CLOCK_TIMESTAMP=1)
 endif()
 
 ### Set up concurrentqueue stuff
 if(NOT EXISTS ${APEX_SOURCE_DIR}/concurrentqueue)
   include(GitExternal)
   git_external(concurrentqueue
-      https://github.com/cameron314/concurrentqueue.git
-      master
-      VERBOSE)
+    https://github.com/cameron314/concurrentqueue.git
+    master
+    VERBOSE)
 endif()
 
 find_file(
-    CONCURRENTQUEUE_HEADER
-    NAMES concurrentqueue.h
-    PATHS ${APEX_SOURCE_DIR}/concurrentqueue)
+  CONCURRENTQUEUE_HEADER
+  NAMES concurrentqueue.h
+  PATHS ${APEX_SOURCE_DIR}/concurrentqueue)
 
 if(CONCURRENTQUEUE_HEADER)
-    message(INFO " Found concurrentqueue at ${APEX_SOURCE_DIR}/concurrentqueue")
+  message(INFO " Found concurrentqueue at ${APEX_SOURCE_DIR}/concurrentqueue")
 else()
-    message(FATAL_ERROR " concurrentqueue not found. This should have been checked out automatically. "
-            "Try manually check out https://github.com/cameron314/concurrentqueue.git to ${APEX_SOURCE_DIR}")
+  message(FATAL_ERROR " concurrentqueue not found. This should have been checked out automatically. "
+    "Try manually check out https://github.com/cameron314/concurrentqueue.git to ${APEX_SOURCE_DIR}")
 endif()
 
 ################################################################################
@@ -126,15 +128,15 @@ else()
 endif()
 
 # this will be statically linked to the core HPX library
-add_definitions(-DHPX_EXPORTS)
-add_definitions(-DHPX_COROUTINE_EXPORTS)
+target_compile_definitions(apex_flags INTERFACE HPX_EXPORTS)
+target_compile_definitions(apex_flags INTERFACE HPX_COROUTINE_EXPORTS)
 
 if(NOT MSVC)
-  add_definitions(-fPIC)
+  target_compile_options(apex_flags INTERFACE -fPIC)
 else()
-  add_definitions(-D_WINDOWS)
-  add_definitions(-D_WIN32)
-  add_definitions(-D_WIN32_WINNT=0x0601)
+  target_compile_definitions(apex_flags INTERFACE -D_WINDOWS)
+  target_compile_definitions(apex_flags INTERFACE -D_WIN32)
+  target_compile_definitions(apex_flags INTERFACE -D_WIN32_WINNT=0x0601)
   hpx_add_compile_flag(-wd4800)     # forcing value to bool 'true' or 'false' (performance warning)
   hpx_add_compile_flag(-wd4244)     # conversion from '...' to '...', possible loss of data
   hpx_add_compile_flag(-wd4267)     # conversion from '...' to '...', possible loss of data
@@ -170,39 +172,106 @@ else()
   hpx_add_compile_flag(-MP)     # Multiprocessor build
 endif()
 
+# Proc
 if(EXISTS "/proc/stat" AND NOT APEX_DISABLE_PROC)
-    hpx_info("apex" "Building APEX with /proc/stat sampler")
-    set(APEX_HAVE_PROC TRUE)
-    add_definitions(-DAPEX_HAVE_PROC)
+  hpx_info("apex" "Building APEX with /proc/stat sampler")
+  set(APEX_HAVE_PROC TRUE)
+  target_compile_definitions(apex_flags INTERFACE APEX_HAVE_PROC)
+  set(proc_headers proc_read.h)
+  set(proc_sources proc_read.cpp)
 endif()
-
 
 if("${HOST_BASENAME}" STREQUAL "edison")
     hpx_info("apex" "This is Edison, will build with Cray Power support")
     set(APEX_HAVE_CRAY_POWER TRUE)
-    add_definitions(-DAPEX_HAVE_CRAY_POWER)
+    target_compile_definitions(apex_flags INTERFACE APEX_HAVE_CRAY_POWER)
 else()
     hpx_info("apex" "This is not edison")
 endif()
 
-if(APEX_HAVE_PROC)
-    set(PROC_SOURCE proc_read.cpp)
-    set(PROC_HEADER proc_read.h)
-endif()
-
-IF("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   hpx_info("apex" "APEX is being built with a debug configuration")
-  add_definitions(-DDEBUG)
+  target_compile_definitions(apex_flags INTERFACE DEBUG)
 endif()
 
-#include(GitExternal)
-#git_external(rapidjson
-    #https://github.com/miloyip/rapidjson.git
-    #master
-    #VERBOSE)
-#include_directories("${PROJECT_BINARY_DIR}/apex/src/apex/rapidjson/include")
-#include_directories("${PROJECT_SOURCE_DIR}/apex/src/apex/rapidjson/include")
 
+#######################################################
+# We create one target per imported library (cleaner) #
+set(_apex_imported_targets "")
+
+# Setup PAPI
+include(APEX_SetupPAPI)
+
+# Setup LM Sensors
+include(APEX_SetupLMSensors)
+if(APEX_WITH_LM_SENSORS)
+  set(sensor_sources sensor_data.cpp)
+endif()
+
+# Setup Active Harmony
+include(APEX_SetupActiveHarmony)
+
+# Currently setup Rapidjson
+include(APEX_SetupPlugins)
+
+if((DEFINED RCR_ROOT) OR (APEX_WITH_RCR) OR (APEX_BUILD_RCR))
+	find_package(RCR)
+endif()
+
+# RCR
+if(HAVE_RCR)
+	hpx_add_config_define(HPX_HAVE_RCR 1)
+else()
+  if(("${HOST_BASENAME}" STREQUAL "edison") OR ("$ENV{NERSC_HOST}" STREQUAL "edison") OR
+    ("${HOST_BASENAME}" STREQUAL "cori") OR ("$ENV{NERSC_HOST}" STREQUAL "cori"))
+    #add_definitions(-fPIC)
+    set (APEX_HAVE_CRAY_POWER TRUE)
+    target_compile_definitions(apex_flags INTERFACE APEX_HAVE_CRAY_POWER)
+    message(INFO " System has Cray energy monitoring support.")
+  else()
+    if(EXISTS "/sys/class/powercap/intel-rapl/intel-rapl:0")
+      set (APEX_HAVE_POWERCAP_POWER TRUE)
+      target_compile_definitions(apex_flags INTERFACE APEX_HAVE_POWERCAP_POWER)
+      message(INFO " System has Powercap energy monitoring support.")
+    endif()
+  endif()
+endif()
+
+# JUPYTER
+if(APEX_WITH_JUPYTER_SUPPORT)
+  target_compile_definitions(apex_flags INTERFACE APEX_WITH_JUPYTER_SUPPORT)
+  message(INFO " Including Jupyter Notebook support.")
+endif(APEX_WITH_JUPYTER_SUPPORT)
+
+# Setup BFD
+if((DEFINED BFD_ROOT) OR (APEX_WITH_BFD) OR (APEX_BUILD_BFD))
+  set(USE_BFD ${APEX_WITH_BFD})
+  set(BUILD_BFD ${APEX_BUILD_BFD})
+  # Setup BFD
+  include(APEX_SetupBFD)
+  set(bfd_sources apex_bfd.cpp address_resolution.cpp)
+  # Setup DEMANGLE
+  include(APEX_SetupDemangle)
+  # Setup Zlib
+	if(NOT APEX_INTEL_MIC)
+    include(APEX_SetupZlib)
+	endif(NOT APEX_INTEL_MIC)
+else()
+	add_custom_target(project_binutils)
+endif()
+
+# Setup MSR
+include(APEX_SetupMSR)
+
+# Setup OTF2
+include(APEX_SetupOTF2)
+if(APEX_WITH_OTF2)
+  set(otf2_headers otf2_listener.hpp)
+  set(otf2_sources otf2_listener.cpp)
+endif()
+
+##################################
+# Setup main apex static library #
 set(apex_headers
     apex.h
     apex.hpp
@@ -226,161 +295,10 @@ set(apex_headers
     task_wrapper.hpp
     tau_listener.hpp
     utils.hpp
-    ${PROC_HEADER})
+    ${proc_headers}
+    ${otf2_headers}
+    )
     #apex_config.h
-
-if(APEX_WITH_PAPI)
-    find_package(PAPI)
-    if(NOT PAPI_FOUND)
-        hpx_error("apex" "Requested APEX_WITH_PAPI but could not find PAPI. Please specify PAPI_ROOT.")
-    endif()
-    hpx_info("apex" "Building APEX with PAPI support.")
-    include_directories(${PAPI_INCLUDE_DIR})
-    set(LIBS ${LIBS} ${PAPI_LIBRARIES})
-    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${PAPI_LIBRARY_DIR})
-    add_definitions(-DAPEX_HAVE_PAPI)
-    hpx_libraries(${PAPI_LIBRARIES})
-endif()
-
-################################################################################
-# LM Sensors configuration
-################################################################################
-
-if(APEX_WITH_LM_SENSORS)
-    find_package(LMSensors)
-    if (LM_SENSORS_FOUND)
-        include_directories(${LM_SENSORS_INCLUDE_DIRS})
-        set(LIBS ${LIBS} ${LM_SENSORS_LIBRARIES})
-        set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${LM_SENSORS_LIBRARY_DIR})
-        add_definitions(-DAPEX_HAVE_LM_SENSORS)
-        hpx_libraries(${LM_SENSORS_LIBRARIES})
-        SET(SENSOR_SOURCE sensor_data.cpp)
-    endif()
-endif()
-
-if(APEX_WITH_ACTIVEHARMONY)
-    find_package(ActiveHarmony)
-    if(NOT ACTIVEHARMONY_FOUND)
-        hpx_error("apex" "Requested APEX_WITH_ACTIVEHARMONY but could not find Active Harmony. Please specify ACTIVEHARMONY_ROOT.")
-    endif()
-    hpx_info("apex" "Building APEX with Active Harmony support.")
-    include_directories(${ACTIVEHARMONY_INCLUDE_DIR})
-    set(LIBS ${LIBS} ${ACTIVEHARMONY_LIBRARIES})
-    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${ACTIVEHARMONY_LIBRARY_DIR})
-    add_definitions(-DAPEX_HAVE_ACTIVEHARMONY)
-    hpx_libraries(${ACTIVEHARMONY_LIBRARIES})
-else()
-    add_custom_target(project_activeharmony)
-endif()
-
-if(APEX_WITH_PLUGINS)
-    message(INFO " apex will be built with plugin support.")
-    set(LIBS ${LIBS} ${CMAKE_DL_LIBS})
-    add_definitions("-DAPEX_USE_PLUGINS")
-
-	git_external(rapidjson
-    	https://github.com/miloyip/rapidjson.git
-    	master
-    	VERBOSE)
-
-	find_path(
-    	RAPIDJSON_INCLUDE_DIR
-    	NAMES rapidjson
-    	PATHS ${APEX_SOURCE_DIR}/rapidjson/include)
-
-	if(RAPIDJSON_INCLUDE_DIR)
-    	message(INFO " Found rapidjson at ${RAPIDJSON_INCLUDE_DIR}")
-    	include_directories(${RAPIDJSON_INCLUDE_DIR})
-	else()
-    	message(FATAL_ERROR " rapidjson not found. This should have been checked out automatically. "
-        	"Try manually check out https://github.com/miloyip/rapidjson.git to ${PROJECT_SOURCE_DIR}")
-	endif()
-endif()
-
-if((DEFINED RCR_ROOT) OR (APEX_WITH_RCR) OR (APEX_BUILD_RCR))
-	find_package(RCR)
-endif()
-
-if(HAVE_RCR)
-	hpx_add_config_define(HPX_HAVE_RCR 1)
-else()
-   	IF(("${HOST_BASENAME}" STREQUAL "edison") OR ("$ENV{NERSC_HOST}" STREQUAL "edison") OR
-      	("${HOST_BASENAME}" STREQUAL "cori") OR ("$ENV{NERSC_HOST}" STREQUAL "cori"))
-       	#add_definitions(-fPIC)
-       	set (APEX_HAVE_CRAY_POWER TRUE)
-       	add_definitions(-DAPEX_HAVE_CRAY_POWER)
-       	message(INFO " System has Cray energy monitoring support.")
-   	else()
-     	if(EXISTS "/sys/class/powercap/intel-rapl/intel-rapl:0")
-       	    set (APEX_HAVE_POWERCAP_POWER TRUE)
-       	    add_definitions(-DAPEX_HAVE_POWERCAP_POWER)
-       	    message(INFO " System has Powercap energy monitoring support.")
-     	endif()
-   	endif()
-endif()
-
-if(APEX_WITH_JUPYTER_SUPPORT)
-    add_definitions(-DAPEX_WITH_JUPYTER_SUPPORT)
-    message(INFO " Including Jupyter Notebook support.")
-endif(APEX_WITH_JUPYTER_SUPPORT)
-
-if((DEFINED BFD_ROOT) OR (APEX_WITH_BFD) OR (APEX_BUILD_BFD))
-    set(USE_BFD ${APEX_WITH_BFD})
-    set(BUILD_BFD ${APEX_BUILD_BFD})
-    find_package(BFD)
-    if (BFD_FOUND)
-        include_directories(${BFD_INCLUDE_DIRS})
-        set(LIBS ${LIBS} ${BFD_LIBRARIES})
-        set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${BFD_LIBRARY_DIR})
-        hpx_libraries(${BFD_LIBRARIES})
-        message(INFO " Using binutils: ${BFD_LIBRARY_DIR} ${BFD_LIBRARIES}")
-        set(BFD_SOURCE apex_bfd.cpp address_resolution.cpp)
-	endif()
-
-	find_package(Demangle)
-	if (DEMANGLE_FOUND)
-		include_directories(${DEMANGLE_INCLUDE_DIRS})
-		set(LIBS ${LIBS} ${DEMANGLE_LIBRARIES})
-		set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${DEMANGLE_LIBRARY_DIR})
-        hpx_libraries(${DEMANGLE_LIBRARIES})
-        message(INFO " Using demangle: ${DEMANGLE_LIBRARY_DIR} ${DEMANGLE_LIBRARIES}")
-	else()
-  	unset(DEMANGLE_LIBRARY)
-  	unset(DEMANGLE_LIBRARIES)
-  	unset(DEMANGLE_DIR)
-	endif()
-	if(NOT APEX_INTEL_MIC)
-		find_package(ZLIB)
-		if (ZLIB_FOUND)
-			set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
-			set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${ZLIB_LIBRARY_DIR})
-            hpx_libraries(${ZLIB_LIBRARIES})
-        	message(INFO " Using zlib: ${ZLIB_LIBRARY_DIR} ${ZLIB_LIBRARIES}")
-		endif()
-	endif(NOT APEX_INTEL_MIC)
-else()
-	add_custom_target(project_binutils)
-endif()
-
-if(APEX_WITH_MSR)
-    find_package(MSR)
-    if(NOT MSR_FOUND)
-        hpx_error("apex" "Requested APEX_WITH_MSR but could not find MSR. Please specify MSR_ROOT.")
-    endif()
-    hpx_info("apex" "Building APEX with libmsr support.")
-    include_directories(${MSR_INCLUDE_DIR})
-    set(LIBS ${LIBS} ${MSR_LIBRARIES})
-    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${MSR_LIBRARY_DIR})
-    add_definitions(-DAPEX_HAVE_MSR)
-    hpx_libraries(${MSR_LIBRARIES})
-endif()
-
-if (APEX_USE_WEAK_SYMBOLS)
-    add_definitions(-DAPEX_USE_WEAK_SYMBOLS)
-else()
-    find_library(DYNAMICLIB dl)
-    hpx_libraries(${DYNAMICLIB})
-endif (APEX_USE_WEAK_SYMBOLS)
 
 set(apex_sources
     apex.cpp
@@ -396,25 +314,11 @@ set(apex_sources
     tau_dummy.cpp
     thread_instance.cpp
     utils.cpp
-    ${BFD_SOURCE}
-    ${SENSOR_SOURCE}
-    ${PROC_SOURCE})
-
-if(APEX_WITH_OTF2)
-    find_package(OTF2 REQUIRED)
-    if (NOT OTF2_FOUND)
-        hpx_error("apex" "Requested APEX_WITH_OTF2 but could not find OTF2 library. Please specify OTF2_ROOT.")
-    endif()
-    include_directories(${OTF2_INCLUDE_DIRS})
-    set(LIBS ${LIBS} ${OTF2_LIBRARIES})
-    set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${OTF2_LIBRARY_DIR})
-    set(apex_headers ${apex_headers} otf2_listener.hpp)
-    set(apex_sources ${apex_sources} otf2_listener.cpp)
-    #add_definitions(-DAPEX_USE_CLOCK_TIMESTAMP=1)
-    hpx_libraries(${OTF2_LIBRARIES})
-else()
-    add_custom_target(project_otf2)
-endif()
+    ${proc_sources}
+    ${bfd_sources}
+    ${sensor_sources}
+    ${otf2_sources}
+    )
 
 #add_hpx_library(taudummy SHARED NOLIBS SOURCES tau_dummy.cpp HEADERS ${apex_headers} FOLDER "Core/Dependencies")
 
@@ -453,7 +357,6 @@ add_hpx_library(apex
     hpx_thread_support
     hpx_topology
     hpx_util
-    ${LIBS}
   FOLDER "Core/Dependencies")
 
 target_include_directories(apex PUBLIC
@@ -462,17 +365,37 @@ target_include_directories(apex PUBLIC
     $<BUILD_INTERFACE:${APEX_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
+# To have the compile options and definitions
+target_link_libraries(apex PUBLIC apex_flags)
+
+# Link to all imported targets
+foreach(lib IN LISTS _apex_imported_targets)
+  if (TARGET "${lib}")
+    target_link_libraries(apex PUBLIC ${lib})
+  endif()
+endforeach()
+
+# Link to dl
+if (APEX_USE_WEAK_SYMBOLS)
+  target_compile_definitions(apex_flags INTERFACE APEX_USE_WEAK_SYMBOLS)
+else()
+  find_library(DYNAMICLIB dl)
+  target_link_libraries(apex PUBLIC ${DYNAMICLIB})
+endif (APEX_USE_WEAK_SYMBOLS)
+
+
 #if(APPLE)
   #hpx_add_link_flag("-weak_library libhpx_taudummy.dylib -flat_namespace")
 #endif(APPLE)
 # add_hpx_pseudo_dependencies (apex_lib taudummy_lib project_activeharmony project_binutils project_otf2)
 
+# TODO: see how to remove those global include directories
 # add the binary tree to the search path for include files
 # so that we will find apex_config.h
 if(HAVE_RCR)
-include_directories("${PROJECT_BINARY_DIR}/apex/src/apex" ${RCR_INCLUDE_PATH})
+  target_include_directories(apex PUBLIC "${PROJECT_BINARY_DIR}/apex/src/apex" ${RCR_INCLUDE_PATH})
 else()
-include_directories("${PROJECT_BINARY_DIR}/apex/src/apex")
+  target_include_directories(apex PUBLIC "${PROJECT_BINARY_DIR}/apex/src/apex")
 endif()
 
 configure_file (


### PR DESCRIPTION
Use CMake target based directives to avoid global include directories and useless linkage.