### PR TITLE
Fix cuda nvml gpu timers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,6 +721,8 @@ if (APEX_WITH_CUDA)
     if (NVML_FOUND)
         message(INFO " Using NVML include: ${NVML_INCLUDE_DIRS}")
         include_directories(${NVML_INCLUDE_DIRS})
+    else()
+        message(INFO " NVML not found, NVML-based GPU counters will be disabled")
     endif()
 endif (APEX_WITH_CUDA)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,12 +714,14 @@ endif(ZLIB_FOUND)
 
 if (APEX_WITH_CUDA)
     find_package(CUPTI REQUIRED)
-    #find_package(NVML REQUIRED)
+    find_package(NVML QUIET)
     add_definitions(-DAPEX_WITH_CUDA)
     message(INFO " Using CUPTI include: ${CUPTI_INCLUDE_DIRS}")
     include_directories(${CUPTI_INCLUDE_DIRS})
-    #message(INFO " Using NVML include: ${NVML_INCLUDE_DIRS}")
-    #include_directories(${NVML_INCLUDE_DIRS})
+    if (NVML_FOUND)
+        message(INFO " Using NVML include: ${NVML_INCLUDE_DIRS}")
+        include_directories(${NVML_INCLUDE_DIRS})
+    endif()
 endif (APEX_WITH_CUDA)
 
 ################################################################################

--- a/cmake/Modules/FindNVML.cmake
+++ b/cmake/Modules/FindNVML.cmake
@@ -22,8 +22,10 @@ set(NVML_ARCH_ROOT ${NVML_ROOT}/targets/x86_64-linux)
 find_path(NVML_INCLUDE_DIR NAMES nvml.h
 	HINTS ${CUDAToolkit_INCLUDE_DIRS} ${NVML_ROOT}/include ${NVML_ARCH_ROOT}/include)
 
-find_library(NVML_LIBRARY NAMES nvml nvidia-ml
-	HINTS ${CUDAToolkit_LIBRARY_DIR} ${NVML_ROOT} ${NVML_ROOT}/lib64 ${NVML_ROOT}/lib ${NVML_ARCH_ROOT} ${NVML_ARCH_ROOT}/lib64 ${NVML_ARCH_ROOT}/lib ${NVML_ROOT}/lib64/stubs ${NVML_ROOT}/lib/stubs)
+find_library(NVML_LIBRARY
+    NAMES nvml nvidia-ml libnvml.so.1 libnvidia-ml.so.1
+	HINTS ${CUDAToolkit_LIBRARY_DIR} ${NVML_ROOT} ${NVML_ROOT}/lib64 ${NVML_ROOT}/lib ${NVML_ARCH_ROOT} ${NVML_ARCH_ROOT}/lib64 ${NVML_ARCH_ROOT}/lib ${NVML_ROOT}/lib64/stubs ${NVML_ROOT}/lib/stubs
+    PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE} /usr/lib64 /usr/lib)
 
 find_library(CUDA_LIBRARY NAMES cudart
     HINTS ${CUDAToolkit_LIBRARY_DIR})
@@ -42,4 +44,3 @@ if(NVML_FOUND)
   set(NVML_DIR ${NVML_ROOT})
   add_definitions(-DAPEX_HAVE_NVML)
 endif()
-

--- a/src/apex/CMakeLists_standalone.cmake
+++ b/src/apex/CMakeLists_standalone.cmake
@@ -170,11 +170,11 @@ if (APEX_WITH_CUDA)
     add_definitions(-DAPEX_WITH_CUDA)
     include_directories (${CUDAToolkit_INCLUDE_DIR})
     include_directories(${CUPTI_INCLUDE_DIRS})
-    include_directories(${NVML_INCLUDE_DIRS})
     if (CUPTI_FOUND)
         SET(CUPTI_SOURCE cupti_trace.cpp)
     endif(CUPTI_FOUND)
     if (NVML_FOUND)
+        include_directories(${NVML_INCLUDE_DIRS})
         SET(NVML_SOURCE apex_nvml.cpp)
     endif(NVML_FOUND)
     add_library (apex_cuda
@@ -378,4 +378,3 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/APEXConfig.cmake
     DESTINATION lib/cmake/APEX
     )
-

--- a/src/apex/cupti_trace.cpp
+++ b/src/apex/cupti_trace.cpp
@@ -28,7 +28,9 @@
 #include "perfetto_listener.hpp"
 #endif
 #include "trace_event_listener.hpp"
+#ifdef APEX_HAVE_NVML
 #include "apex_nvml.hpp"
+#endif
 #ifdef APEX_HAVE_OTF2
 #include "otf2_listener.hpp"
 #endif
@@ -1712,7 +1714,9 @@ void apex_cupti_callback_dispatch(void *ud, CUpti_CallbackDomain domain,
             uint32_t context{0};
             cuptiGetDeviceId(cbdata->context, &device);
             cuptiGetContextId(cbdata->context, &context);
+#ifdef APEX_HAVE_NVML
             apex::nvml::monitor::activateDeviceIndex(device);
+#endif
             map_mutex.lock();
             context_map[context] = device;
             map_mutex.unlock();


### PR DESCRIPTION
Refs #192.

In the standalone CUDA build, `libapex_cuda.so` may fail to load when NVML is not available.

The problem is that `cupti_trace.cpp` calls NVML unconditionally, while `apex_nvml.cpp` is only compiled when NVML is found. In that case, CUPTI does not initialize, and APEX ends up reporting no `GPU Timers`.

This patch makes that code path safe by using NVML only when it is actually available.

I tested this locally with a small Kokkos/CUDA reproducer on CUDA 13.0, and also with [apex-kokkos-tuning](https://github.com/khuck/apex-kokkos-tuning):
`./install/bin/apex_exec --apex:kokkos --apex:kokkos-fence --apex:monitor-gpu --apex:cuda ./build/tests/mdrange_gemm_occupancy`

With this change, `GPU Timers` shows up again as expected.


<img width="653" height="1287" alt="Capture d’écran du 2026-04-03 15-02-33" src="https://github.com/user-attachments/assets/ab0f5ff3-c04b-427f-95d1-0773be179f7e" />