### PR TITLE
Fix Kokkos tuning cache replay after YAML format change

### DIFF
--- a/src/apex/apex_kokkos_tuning.cpp
+++ b/src/apex/apex_kokkos_tuning.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <numeric>
 #include <stdlib.h>
 #include "apex.hpp"
 #include "Kokkos_Profiling_C_Interface.h"
@@ -832,10 +833,8 @@ std::string hashContext(size_t numVars,
     /* Sort by the variable name, not the runtime-assigned ID. Kokkos can
      * reuse the same logical variables with different IDs across runs, and
      * cache replay depends on the context hash staying stable. */
-    std::vector<size_t> reindex;
-    for (size_t i = 0 ; i < numVars ; i++) {
-        reindex.push_back(i);
-    }
+    std::vector<size_t> reindex(numVars);
+    std::iota(reindex.begin(), reindex.end(), 0);
     sort(reindex.begin(), reindex.end(),
             [&](const auto& lhs, const auto& rhs) {
                 const auto lhs_id = values[lhs].type_id;

--- a/src/apex/apex_kokkos_tuning.cpp
+++ b/src/apex/apex_kokkos_tuning.cpp
@@ -463,8 +463,12 @@ void KokkosSession::parseVariableCache(std::ifstream& results) {
     std::string delimiter = ": ";
     struct Kokkos_Tools_VariableInfo info;
     memset(&info, 0, sizeof(struct Kokkos_Tools_VariableInfo));
-    // name
+    // hash (newer cache format) or name (older cache format)
     std::getline(results, line);
+    if (line.find("hash", 0) != std::string::npos) {
+        std::getline(results, line);
+    }
+    // name
     std::string name = line.substr(line.find(delimiter)+2);
     // id
     std::getline(results, line);
@@ -825,21 +829,32 @@ std::string hashContext(size_t numVars,
     std::map<size_t, Variable*>& varmap, std::string tree_node) {
     std::stringstream ss;
     std::string d{"["};
-    /* This is REALLY annoying. sometimes the order of the variables
-     * can change, not sure how Kokkos is doing that but it may be a
-     * side effect of using an unordered map. regardless, we have to
-     * sort the variables by ID to make sure we generate the hash
-     * consistently. */
-    std::vector<std::pair<size_t,size_t>> reindex;
+    /* Sort by the variable name, not the runtime-assigned ID. Kokkos can
+     * reuse the same logical variables with different IDs across runs, and
+     * cache replay depends on the context hash staying stable. */
+    std::vector<size_t> reindex;
     for (size_t i = 0 ; i < numVars ; i++) {
-        reindex.push_back(std::pair<size_t,size_t>(i,values[i].type_id));
+        reindex.push_back(i);
     }
     sort(reindex.begin(), reindex.end(),
-            [](const auto& lhs, const auto& rhs) {
-                return lhs.second < rhs.second;
+            [&](const auto& lhs, const auto& rhs) {
+                const auto lhs_id = values[lhs].type_id;
+                const auto rhs_id = values[rhs].type_id;
+                auto lhs_var = varmap.find(lhs_id);
+                auto rhs_var = varmap.find(rhs_id);
+                std::string lhs_name = (lhs_var != varmap.end() &&
+                    lhs_var->second != nullptr) ? lhs_var->second->name :
+                    std::to_string(lhs_id);
+                std::string rhs_name = (rhs_var != varmap.end() &&
+                    rhs_var->second != nullptr) ? rhs_var->second->name :
+                    std::to_string(rhs_id);
+                if (lhs_name == rhs_name) {
+                    return lhs_id < rhs_id;
+                }
+                return lhs_name < rhs_name;
             });
     for (size_t i = 0 ; i < numVars ; i++) {
-        size_t ri = reindex[i].first;
+        size_t ri = reindex[i];
         auto id = values[ri].type_id;
         Variable* var{varmap[id]};
         ss << d << var->name << ":";
@@ -893,20 +908,26 @@ bool getCachedTunings(std::string name,
     auto result = session.cachedTunings.find(name);
     // don't have a tuning for this context?
     if (result == session.cachedTunings.end()) { return false; }
+    std::map<std::string, const struct Kokkos_Tools_VariableValue*> cachedByName;
+    for (const auto &cachedVar : result->second) {
+        auto cachedName = session.cachedVariableNames.find(cachedVar.first);
+        if (cachedName == session.cachedVariableNames.end()) { return false; }
+        cachedByName.insert(std::make_pair(cachedName->second, &(cachedVar.second)));
+    }
     for (size_t i = 0 ; i < vars ; i++) {
         auto id = values[i].type_id;
         // look up the variable in the outputs, by id - may not match the cached ID
         auto outputVar = session.outputs.find(id);
-        // look up the variable in the cache, by name - the name will always match
+        if (outputVar == session.outputs.end() || outputVar->second == nullptr) {
+            return false;
+        }
+        // look up the variable in the cache by the stable variable name
         std::string varname{outputVar->second->name};
-        // look up the cached ID (it might not match the current variable id from Kokkos)
-        size_t varID = session.cachedVariableIDs.find(varname)->second;
-        auto variter = result->second.find(varID);
-        //auto nameiter = session.cachedVariableNames.find(id);
-        if (variter == result->second.end()) { return false; }
-        //if (nameiter == session.cachedVariableNames.end()) { return false; }
-        auto var = variter->second;
-        //auto varname = nameiter->second;
+        auto variter = cachedByName.find(varname);
+        if (variter == cachedByName.end() || variter->second == nullptr) {
+            return false;
+        }
+        const auto& var = *(variter->second);
         if (var.metadata->type == kokkos_value_double) {
             values[i].value.double_value = var.value.double_value;
             std::string tmp(name+":"+varname);
@@ -1348,4 +1369,3 @@ void kokkosp_end_context(const size_t contextId) {
 }
 
 } // extern "C"
-

--- a/src/unit_tests/Kokkos/CMakeLists.txt
+++ b/src/unit_tests/Kokkos/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT APPLE)
 endif(NOT APPLE)
 
 set(example_programs
+    cache_replay
     simple
     two_var
     ${openmp_programs}
@@ -40,4 +41,3 @@ foreach(example_program ${example_programs})
   set_property(TEST "test_${example_program}_kokkos" APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=4")
 
 endforeach()
-

--- a/src/unit_tests/Kokkos/cache_replay.cpp
+++ b/src/unit_tests/Kokkos/cache_replay.cpp
@@ -1,0 +1,213 @@
+#include "apex.h"
+#include "Kokkos_Profiling_C_Interface.h"
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+extern "C" {
+void kokkosp_init_library(int loadseq, uint64_t version,
+    uint32_t ndevinfos, struct Kokkos_Profiling_KokkosPDeviceInfo* devinfos);
+void kokkosp_finalize_library();
+void kokkosp_declare_output_type(const char* name, const size_t id,
+    Kokkos_Tools_VariableInfo& info);
+void kokkosp_declare_input_type(const char* name, const size_t id,
+    Kokkos_Tools_VariableInfo& info);
+void kokkosp_request_values(
+    const size_t contextId,
+    const size_t numContextVariables,
+    const Kokkos_Tools_VariableValue* contextVariableValues,
+    const size_t numTuningVariables,
+    Kokkos_Tools_VariableValue* tuningVariableValues);
+}
+
+namespace {
+
+/* Regression test for cache replay with the newer YAML layout:
+ * - cached variables include "hash" before "name"
+ * - cached output IDs differ from the runtime IDs
+ * - runtime declarations arrive in a different order than the cache */
+constexpr const char* kConvergedCache = R"(Input_100:
+  hash: 1001
+  name: cache_replay.a_input
+  id: 100
+  info.type: int64
+  info.category: categorical
+  info.valueQuantity: set
+  info.candidates: [1,2]
+Input_200:
+  hash: 1002
+  name: cache_replay.b_input
+  id: 200
+  info.type: int64
+  info.category: categorical
+  info.valueQuantity: set
+  info.candidates: [1,2]
+Output_300:
+  hash: 1003
+  name: cache_replay.a_output
+  id: 300
+  info.type: int64
+  info.category: categorical
+  info.valueQuantity: set
+  info.candidates: [10,20]
+Output_400:
+  hash: 1004
+  name: cache_replay.b_output
+  id: 400
+  info.type: int64
+  info.category: categorical
+  info.valueQuantity: set
+  info.candidates: [10,20]
+Context_0:
+  Name: "[cache_replay.a_input:1,cache_replay.b_input:2,tree_node:cache_replay_context]"
+  Strategy: "exhaustive"
+  Converged: true
+  Results:
+    NumVars: 2
+    id: 300
+    value: 20
+    id: 400
+    value: 10
+)";
+
+struct IntSetInfo {
+    explicit IntSetInfo(std::initializer_list<int64_t> values) {
+        std::memset(&info, 0, sizeof(info));
+        storage.assign(values.begin(), values.end());
+        info.type = kokkos_value_int64;
+        info.category = kokkos_value_categorical;
+        info.valueQuantity = kokkos_value_set;
+        info.candidates.set.size = storage.size();
+        info.candidates.set.values.int_value = storage.data();
+    }
+
+    Kokkos_Tools_VariableInfo info;
+    std::vector<int64_t> storage;
+};
+
+Kokkos_Tools_VariableValue make_int_variable_value(size_t id, int64_t value,
+    Kokkos_Tools_VariableInfo* metadata) {
+    Kokkos_Tools_VariableValue variable;
+    std::memset(&variable, 0, sizeof(variable));
+    variable.type_id = id;
+    variable.value.int_value = value;
+    variable.metadata = metadata;
+    return variable;
+}
+
+std::string make_cache_path() {
+    std::stringstream ss;
+    ss << "/tmp/apex_cache_replay_" << getpid() << ".yaml";
+    return ss.str();
+}
+
+void write_converged_cache(const std::string& filename) {
+    std::ofstream results(filename);
+    results << kConvergedCache;
+}
+
+int report_failure(const std::string& message, const std::string& output,
+    const std::string& cache_file) {
+    std::cerr << message << std::endl;
+    if (!output.empty()) {
+        std::cerr << "Captured output:" << std::endl;
+        std::cerr << output << std::endl;
+    }
+    unlink(cache_file.c_str());
+    return 1;
+}
+
+} // namespace
+
+int main() {
+    const std::string cache_file = make_cache_path();
+    write_converged_cache(cache_file);
+
+    kokkosp_init_library(0, KOKKOSP_INTERFACE_VERSION, 0, nullptr);
+    apex_set_use_kokkos_tuning(true);
+    apex_set_use_kokkos_verbose(true);
+    apex_set_use_screen_output(false);
+    apex_set_kokkos_tuning_cache(strdup(cache_file.c_str()));
+
+    apex_profiler_handle profiler =
+        apex_start(APEX_NAME_STRING, "cache_replay_context");
+
+    IntSetInfo input_info({1, 2});
+    IntSetInfo output_info({10, 20});
+
+    std::ostringstream capture;
+    std::streambuf* old_buffer = std::cout.rdbuf(capture.rdbuf());
+
+    const size_t b_input_id = 11;
+    const size_t a_input_id = 22;
+    const size_t b_output_id = 33;
+    const size_t a_output_id = 44;
+
+    kokkosp_declare_input_type("cache_replay.b_input", b_input_id,
+        input_info.info);
+    kokkosp_declare_input_type("cache_replay.a_input", a_input_id,
+        input_info.info);
+    kokkosp_declare_output_type("cache_replay.b_output", b_output_id,
+        output_info.info);
+    kokkosp_declare_output_type("cache_replay.a_output", a_output_id,
+        output_info.info);
+
+    std::array<Kokkos_Tools_VariableValue, 2> inputs{
+        make_int_variable_value(b_input_id, 2, &input_info.info),
+        make_int_variable_value(a_input_id, 1, &input_info.info)
+    };
+
+    std::array<Kokkos_Tools_VariableValue, 2> outputs{
+        make_int_variable_value(b_output_id, -1, &output_info.info),
+        make_int_variable_value(a_output_id, -1, &output_info.info)
+    };
+
+    kokkosp_request_values(7, inputs.size(), inputs.data(), outputs.size(),
+        outputs.data());
+
+    std::cout.rdbuf(old_buffer);
+    apex_stop(profiler);
+    kokkosp_finalize_library();
+    apex_finalize();
+    apex_cleanup();
+
+    const std::string output = capture.str();
+
+    int64_t a_output = -1;
+    int64_t b_output = -1;
+    for (const auto& value : outputs) {
+        if (value.type_id == a_output_id) {
+            a_output = value.value.int_value;
+        } else if (value.type_id == b_output_id) {
+            b_output = value.value.int_value;
+        }
+    }
+
+    if (output.find("Reading cache of Kokkos tuning results") ==
+        std::string::npos) {
+        return report_failure(
+            "Cache replay test did not read the expected cache file.",
+            output, cache_file);
+    }
+    if (output.find("Starting tuning session") != std::string::npos) {
+        return report_failure(
+            "Cache replay test unexpectedly started a fresh tuning session.",
+            output, cache_file);
+    }
+    if (a_output != 20 || b_output != 10) {
+        std::stringstream ss;
+        ss << "Cache replay test returned unexpected outputs: "
+           << "a_output=" << a_output << ", b_output=" << b_output;
+        return report_failure(ss.str(), output, cache_file);
+    }
+
+    unlink(cache_file.c_str());
+    return 0;
+}


### PR DESCRIPTION
This PR is related to #194

APEX reads the cached Kokkos tuning YAML file, but replay fails because parseVariableCache() still assumes the old field order, corrupts the variable name/ID mapping, and starts a new tuning session instead of reusing the converged cache.